### PR TITLE
Feat mutfileupload

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,26 @@
 This is a tool that supports uploading images directly to the image bed [Lsky](https://github.com/lsky-org/lsky-pro), based on [renmu123/obsidian-image-auto-upload-plugin](https://github.com/renmu123/obsidian-image-auto-upload-plugin.git) modification.
 **Remember to restart Obsidian after updating the plugin**
 
+## What's New (this commit)
+
+- Added a new command: `Upload all images - All notes in vault (reuse)`.
+  - Scans all Markdown notes in your vault and uploads local images, then replaces links with uploaded URLs.
+  - Reuses the existing `uploadAllFile(currentFile?: TFile)` method for each note to avoid duplicated logic.
+- Refactored `uploadAllFile` to accept a `TFile` parameter and run sequentially (`await`).
+  - When called for the active note, it uses the editor content and updates via the editor.
+  - When called for non-active notes, it reads the file from the vault and writes back with updated links.
+- Updated the existing "Upload all images" command to pass the active file to the refactored method.
+
+### How to use the new command
+
+1. Open the command palette (`Ctrl+P`).
+2. Run `Upload all images - All notes in vault (reuse)`.
+3. The plugin will iterate all `.md` files, upload local images, and replace references; a summary notice appears when done.
+
+Notes:
+- Local images are uploaded; handling of network images respects your current settings (`workOnNetWork` and black domain filters).
+- Relative and absolute paths are resolved consistently, same as the current-file command.
+
 # Start
 
 1. Install the LskyPro image bed and configure it. For configuration, refer to [official website](https://www.lsky.pro/)
@@ -30,6 +50,11 @@ image-auto-upload: true
 ## Upload all local images file by command
 
 press ctrl+P and input upload all images，enter, then will auto upload all local images
+
+You can also process all notes at once with the new command:
+
+- Open the command palette and run: `Upload all images - All notes in vault (reuse)`
+- It will reuse the same logic per note and update links across the vault.
 
 The path resolution priority will be searched according to the priority in turn:
 

--- a/readme-zh.md
+++ b/readme-zh.md
@@ -3,6 +3,26 @@
 这是一个支持直接上传图片到图床[Lsky](https://github.com/lsky-org/lsky-pro)的工具，基于[renmu123/obsidian-image-auto-upload-plugin](https://github.com/renmu123/obsidian-image-auto-upload-plugin.git)改造。
 **更新插件后记得重启一下 Obsidian**
 
+## 本次提交更新内容
+
+- 新增命令：`Upload all images - All notes in vault (reuse)`。
+  - 扫描库中所有 Markdown 笔记，上传本地图片并将引用统一替换为外链。
+  - 复用已有方法 `uploadAllFile(currentFile?: TFile)` 逐个处理文件，避免重复逻辑。
+- 重构 `uploadAllFile`：支持传入 `TFile` 参数并顺序执行（`await`）。
+  - 当处理当前激活文件时，使用编辑器内容并通过编辑器更新。
+  - 当处理非激活文件时，从 vault 读取内容，处理后直接写回文件。
+- 更新原有“上传当前文件所有图片”的命令，使其向改造后的方法传入当前激活文件。
+
+### 新命令使用方式
+
+1. 打开命令面板（`Ctrl+P`）。
+2. 输入并执行：`Upload all images - All notes in vault (reuse)`。
+3. 插件会遍历所有 `.md` 文件，上传本地图片并替换引用，完成后会弹出统计提示。
+
+说明：
+- 本地图片会被上传；网络图片的处理遵循现有设置（`workOnNetWork` 与黑名单域名过滤）。
+- 相对路径与绝对路径的解析与当前文件命令保持一致。
+
 # 开始
 
 1. 安装 LskyPro 图床，并进行配置，配置参考[官网](https://www.lsky.pro/)
@@ -30,6 +50,11 @@ image-auto-upload: true
 ## 批量上传一个文件中的所有图像文件
 
 输入 `ctrl+P` 呼出面板，输入 `upload all images`，点击回车，就会自动开始上传。
+
+现在也可以一次性处理所有笔记：
+
+- 打开命令面板并执行：`Upload all images - All notes in vault (reuse)`
+- 插件会复用同样的逻辑逐个处理并替换链接。
 
 路径解析优先级，会依次按照优先级查找：
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,6 +97,22 @@ export default class imageAutoUploadPlugin extends Plugin {
         return false;
       },
     });
+    this.addCommand({
+      id: "Upload all images in all notes (reuse)",
+      name: "Upload all images - All notes in vault (reuse)",
+      checkCallback: (checking: boolean) => {
+        const hasMarkdown = this.app.vault
+          .getFiles()
+          .some(f => f.path.endsWith(".md"));
+        if (hasMarkdown) {
+          if (!checking) {
+            this.uploadAllNotesByUploadAllFile();
+          }
+          return true;
+        }
+        return false;
+      },
+    });
 
     this.setupPasteHandler();
     this.registerSelection();
@@ -383,50 +399,61 @@ export default class imageAutoUploadPlugin extends Plugin {
     }
 
     if (imageList.length === 0) {
-      new Notice("没有解析到图像文件");
+      new Notice(`${activeFile.path}没有解析到图像文件`);
       return;
     } else {
-      new Notice(`共找到${imageList.length}个图像文件，开始上传`);
+      new Notice(`${activeFile.path}共找到${imageList.length}个图像文件，开始上传`);
     }
 
-    this.uploader.uploadFilesByPath(imageList.map(item => item.obspath)).then(res => {
-      if (res.success) {
-        let uploadUrlList = res.result;
-        const uploadUrlFullResultList = res.fullResult || [];
+    const res = await this.uploader.uploadFilesByPath(
+      imageList.map(item => item.obspath)
+    );
+    if (res.success) {
+      let uploadUrlList = res.result;
+      const uploadUrlFullResultList = res.fullResult || [];
 
-        this.settings.uploadedImages = [
-          ...(this.settings.uploadedImages || []),
-          ...uploadUrlFullResultList,
-        ];
-        this.saveSettings();
-        imageList.map(item => {
-          const uploadImage = uploadUrlList.shift();
-          content = content.replaceAll(
-            item.source,
-            `![${item.name}${this.settings.imageSizeSuffix || ""
-            }](${uploadImage})`
-          );
-        });
-        if (isActive) {
-          this.helper.setValue(content);
-        } else {
-          this.app.vault.modify(activeFile, content);
-        }
-
-        if (this.settings.deleteSource) {
-          imageList.map(image => {
-            if (!image.path.startsWith("http")) {
-              let fileDel = this.app.vault.getAbstractFileByPath(image.obspath);
-              if (fileDel) {
-                this.app.vault.delete(fileDel);
-              }
-            }
-          });
-        }
+      this.settings.uploadedImages = [
+        ...(this.settings.uploadedImages || []),
+        ...uploadUrlFullResultList,
+      ];
+      await this.saveSettings();
+      imageList.map(item => {
+        const uploadImage = uploadUrlList.shift();
+        content = content.replaceAll(
+          item.source,
+          `![${item.name}${this.settings.imageSizeSuffix || ""}](${uploadImage})`
+        );
+      });
+      if (isActive) {
+        this.helper.setValue(content);
       } else {
-        new Notice("Upload error");
+        await this.app.vault.modify(activeFile, content);
       }
-    });
+
+      if (this.settings.deleteSource) {
+        imageList.map(image => {
+          if (!image.path.startsWith("http")) {
+            let fileDel = this.app.vault.getAbstractFileByPath(image.obspath);
+            if (fileDel) {
+              this.app.vault.delete(fileDel);
+            }
+          }
+        });
+      }
+    } else {
+      new Notice("Upload error");
+    }
+  }
+
+  // upload images across all markdown notes by reusing uploadAllFile
+  async uploadAllNotesByUploadAllFile() {
+    const mdFiles = this.app.vault
+      .getFiles()
+      .filter(f => f.path.endsWith(".md"));
+    for (const md of mdFiles) {
+      await this.uploadAllFile(md);
+    }
+    new Notice(`处理完成，共处理${mdFiles.length}个文件`);
   }
 
   setupPasteHandler() {


### PR DESCRIPTION
- 新增命令：`Upload all images - All notes in vault (reuse)`。
  - 扫描库中所有 Markdown 笔记，上传本地图片并将引用统一替换为外链。
  - 复用已有方法 `uploadAllFile(currentFile?: TFile)` 逐个处理文件，避免重复逻辑。
- 重构 `uploadAllFile`：支持传入 `TFile` 参数并顺序执行（`await`）。
  - 当处理当前激活文件时，使用编辑器内容并通过编辑器更新。
  - 当处理非激活文件时，从 vault 读取内容，处理后直接写回文件。
- 更新原有“上传当前文件所有图片”的命令，使其向改造后的方法传入当前激活文件。
- 优化ts校验